### PR TITLE
[Fix] Include types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pathington CHANGELOG
 
+## 2.0.1
+
+- Fix types not being exposed
+
 ## 2.0.0
 
 Rewrite for modernity! Written in TS from scratch, with a focus on building extremely narrow types, both when creating

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 type PathItem = number | string;
 type Path = PathItem[];
 type ReadonlyPath = readonly PathItem[];
+type NumericKey = `${number}`;
 type Quote = '"' | "'" | '`';
+type QuotedKey = `${Quote}${PathItem}${Quote}`;
 type CreatePath<P, Q extends Quote, S extends number | string> = P extends [infer Key, ...infer Rest]
   ? Key extends number
     ? '.' extends S
@@ -62,3 +64,4 @@ declare function parse<const P extends Path | ReadonlyPath | PathItem>(
 ): string extends P ? Path : ParsePath<P, []>;
 
 export { create, parse };
+export type { CreatePath, NumericKey, ParsePath, Path, PathItem, Quote, QuotedKey, ReadonlyPath };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import type { CreatePath, ParsePath, Path, PathItem, Quote, ReadonlyPath } from 
 import { getNormalizedPathItem } from './utils.js';
 import { isNumericKey, isQuotedKey } from './validate.js';
 
+export type * from './internalTypes.js';
+
 const DOTTY_WITH_BRACKETS_SYNTAX = /"[^"]+"|`[^`]+`|'[^']+'|[^.[\]]+/g;
 const VALID_KEY = /^\d+$|^[a-zA-Z_$][\w$]+$/;
 const VALID_QUOTE = /^["'`]{1}$/;


### PR DESCRIPTION
## Reason for change

Forgot to include the types as part of the top-level export.

## Change

Export the types from `index.ts`.