### PR TITLE
[Enhancement] Add support for symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pathington CHANGELOG
 
+## 2.1.0
+
+- Add support for symbols, including symbol reuse between `create` and `parse`
+
 ## 2.0.2
 
 - Fix more edges in types for `create`, and provide sane fallback for `parse` with wide types

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ const parsedPath = parse(path);
 console.log(parsedPath.at(-1) === symbol); // true
 ```
 
+Because symbol values cannot be statically analyzed for their value by TS in the same way that numbers or strings can, a
+consistent visual representation is used for all symbols:
+
+```ts
+const symbol = Symbol('foo');
+const path = create(['array', 0, 'with', symbol]);
+console.log(path); // array[0].with[Symbol()]
+```
+
 ### parse
 
 `parse(path: (Array<number|string>|string)): string`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Create or parse an object path based on dot or bracket syntax.
 
 - [Usage](#usage)
 - [Methods](#methods)
-  - [parse](#parse)
   - [create](#create)
+  - [parse](#parse)
 - [Browser support](#browser-support)
 - [Development](#development)
 
@@ -27,23 +27,6 @@ console.log(createdPath); // 'some[0].deeply["nested path"]'
 
 ## Methods
 
-### parse
-
-`parse(path: (Array<number|string>|string)): string`
-
-Parse a path into an array of path values.
-
-```javascript
-console.log(parse('simple')); // ['simple']
-console.log(parse('dot.notation')); // ['dot', 'notation']
-console.log(parse('array[0]')); // ['array', 0]
-console.log(parse('array[0].with["quoted keys"]')); // ['array', 0, 'with', 'quoted keys']
-console.log(parse('special["%characters*"]')); // ['special', '%characters*']
-```
-
-- If a path string is provided, it will be parsed into an array
-- If an array is provided, it will be mapped with the keys normalized
-
 ### create
 
 `create(path: Array<number|string>, quote?: '"' | "'" | '```'): string`
@@ -62,3 +45,44 @@ Optionally, you can pass in the quote string to use instead of `"`. Valid values
 ```javascript
 console.log(create(['quoted keys'], "'")); // ['quoted keys']
 ```
+
+#### Symbols
+
+You can provide symbols, and a string path will be created from it:
+
+```ts
+const symbol = Symbol('foo');
+console.log(create(['array', 0, 'with', symbol])); // 'array[0].with[Symbol()]'
+```
+
+This can be used in concert with [`parse`](#parse) to extract the values pack:
+
+```ts
+const symbol = Symbol('foo');
+const path = create(['array', 0, 'with', symbol]);
+const parsedPath = parse(path);
+console.log(parsedPath.at(-1) === symbol); // true
+```
+
+### parse
+
+`parse(path: (Array<number|string>|string)): string`
+
+Parse a path into an array of path values.
+
+```javascript
+console.log(parse('simple')); // ['simple']
+console.log(parse('dot.notation')); // ['dot', 'notation']
+console.log(parse('array[0]')); // ['array', 0]
+console.log(parse('array[0].with["quoted keys"]')); // ['array', 0, 'with', 'quoted keys']
+console.log(parse('special["%characters*"]')); // ['special', '%characters*']
+```
+
+- If a path string is provided, it will be parsed into an array
+- If an array is provided, it will be mapped with the keys normalized
+
+#### Symbols
+
+While symbols can be used with this library, `parse` will only recognize them in a string path when that path is created
+by [`create`](#create). If you try to manually stringify a symbol, it will identiy that value as a string key when
+parsing.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -193,14 +193,14 @@ describe('parse', () => {
   });
 
   test('handles when the string path contans a symbol reference', () => {
-    const path = `foo[${getStringifedSymbolKey(Symbol('foo'))}]`;
+    const path = create(['foo', Symbol('foo')]);
     const result = parse(path);
 
     expect(result).toEqual(['foo', expect.any(Symbol)]);
   });
 
   test('handles when the string path contains a bunch of a symbol references', () => {
-    const path = `[${getStringifedSymbolKey(Symbol('foo'))}].foo["bar.baz"].quz[0][${getStringifedSymbolKey(Symbol('bar'))}].blah[${getStringifedSymbolKey(Symbol('baz'))}]`;
+    const path = create([Symbol('foo'), 'foo', 'bar.baz', 'quz', 0, Symbol('bar'), 'blah', Symbol('baz')]);
     const result = parse(path);
 
     expect(result).toEqual([

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
 import { create, parse } from '../src/index.js';
-import { getStringifedSymbolKey } from '../src/utils.js';
 
 describe('create', () => {
   test('creates a path string when it is dot-notated', () => {
@@ -20,7 +19,7 @@ describe('create', () => {
     const path = Symbol('foo');
     const result = create([path]);
 
-    expect(result).toBe(`[${getStringifedSymbolKey(path)}]`);
+    expect(result).toMatch(/Symbol\(foo\)/);
   });
 
   test('creates a path when a string that should be quoted because of whitespace', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -205,6 +205,13 @@ describe('parse', () => {
 
   test('handles when the path is a symbol reference', () => {
     const symbol = Symbol('foo');
+    const result = parse([symbol]);
+
+    expect(result).toEqual([symbol]);
+  });
+
+  test('handles when the path is a symbol reference in a created string', () => {
+    const symbol = Symbol('foo');
     const path = create([symbol]);
     const result = parse(path);
 

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -5,6 +5,7 @@ export default createEslintConfig({
   configs: [
     {
       rules: {
+        '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/prefer-optional-chain': 'off',
       },
     },

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,23 @@
-type PathItem = number | string;
+type SerializablePathItem = number | string;
+type PathItem = SerializablePathItem | symbol;
 type Path = PathItem[];
 type ReadonlyPath = readonly PathItem[];
+type ParseablePath = Path | ReadonlyPath | PathItem;
 type NumericKey = `${number}`;
 type Quote = '"' | "'" | '`';
-type QuotedKey = `${Quote}${PathItem}${Quote}`;
-type BracketedKey<Key extends PathItem> = `[${Key}]`;
-type BracketedQuotedKey<Key extends PathItem, Q extends Quote> = BracketedKey<`${Q}${Key}${Q}`>;
+type QuotedKey = `${Quote}${SerializablePathItem}${Quote}`;
+type SymbolKey = '<<symbol>>';
+type BracketedKey<Key extends SerializablePathItem> = `[${Key}]`;
+type BracketedQuotedKey<Key extends SerializablePathItem, Q extends Quote> = BracketedKey<`${Q}${Key}${Q}`>;
 type JoinedKey<
-  Key extends PathItem,
+  Key extends SerializablePathItem,
   Q extends Quote,
   S extends string,
   Rest extends unknown[],
   D extends string,
 > = '.' extends S ? CreateNarrowPath<Rest, Q, `${Key}`> : CreateNarrowPath<Rest, Q, `${S}${D}${Key}`>;
 type JoinNarrowPath<
-  Key extends PathItem,
+  Key extends SerializablePathItem,
   Q extends Quote,
   S extends string,
   Rest extends unknown[],
@@ -31,7 +34,9 @@ type CreateNarrowPath<P, Q extends Quote, S extends string> = P extends [infer K
           : Key extends `${string}.${string}`
             ? JoinNarrowPath<BracketedQuotedKey<Key, Q>, Q, S, Rest>
             : JoinNarrowPath<Key, Q, S, Rest, '.'>
-      : S
+      : Key extends symbol
+        ? JoinNarrowPath<BracketedKey<SymbolKey>, Q, S, Rest>
+        : S
   : S;
 type CreatePath<P, Q extends Quote> = string[] extends P
   ? string
@@ -41,7 +46,7 @@ type CreatePath<P, Q extends Quote> = string[] extends P
       ? CreateNarrowPath<[Item, ...Rest], Q, '.'>
       : CreateNarrowPath<P, Q, '.'>;
 type SplitDots<P extends string> = P extends `${infer S}.${infer E}` ? [...SplitDots<S>, ...SplitDots<E>] : [P];
-type SplitString<P extends string, A extends string[]> = P extends `${infer S}[${infer C}].${infer R}`
+type SplitString<P extends string, A extends Array<string | symbol>> = P extends `${infer S}[${infer C}].${infer R}`
   ? '' extends S
     ? [...A, ...SplitString<C, []>, ...SplitString<R, []>]
     : [...A, ...SplitDots<S>, ...SplitString<C, []>, ...SplitString<R, []>]
@@ -59,7 +64,9 @@ type SplitString<P extends string, A extends string[]> = P extends `${infer S}[$
             ? [...A, N]
             : P extends `${Quote}${infer C}${Quote}`
               ? [...A, C]
-              : [...A, ...SplitDots<P>];
+              : SymbolKey extends P
+                ? [...A, symbol]
+                : [...A, ...SplitDots<P>];
 type ParseNarrowPath<P, A extends unknown[]> = P extends [infer Item, ...infer Rest]
   ? Item extends PathItem
     ? ParseNarrowPath<Rest, [...A, Item]>
@@ -69,7 +76,9 @@ type ParseNarrowPath<P, A extends unknown[]> = P extends [infer Item, ...infer R
     : P extends number
       ? [...A, P]
       : P extends string
-        ? SplitString<P, []>
+        ? P extends SymbolKey
+          ? symbol
+          : SplitString<P, []>
         : A;
 type ParsePath<P> = string extends P
   ? [P]
@@ -87,7 +96,20 @@ declare function create<const P extends Path | ReadonlyPath, Q extends Quote = '
   path: P,
   quote?: Q,
 ): CreatePath<P, Q>;
-declare function parse<const P extends Path | ReadonlyPath | PathItem>(path: P): ParsePath<P>;
+declare function parse<const P extends ParseablePath>(path: P): ParsePath<P>;
 
 export { create, parse };
-export type { CreateNarrowPath, CreatePath, NumericKey, ParsePath, Path, PathItem, Quote, QuotedKey, ReadonlyPath };
+export type {
+  CreateNarrowPath,
+  CreatePath,
+  NumericKey,
+  ParsePath,
+  ParseablePath,
+  Path,
+  PathItem,
+  Quote,
+  QuotedKey,
+  ReadonlyPath,
+  SerializablePathItem,
+  SymbolKey,
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ type ParseNarrowPath<P, A extends unknown[]> = P extends [infer Item, ...infer R
     : P extends number
       ? [...A, P]
       : P extends string
-        ? P extends SymbolKey
+        ? SymbolKey extends P
           ? symbol
           : SplitString<P, []>
         : A;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import type { CreatePath, ParseablePath, ParsePath, Path, Quote, ReadonlyPath } from './internalTypes.js';
-import { getNormalizedPathItem, getSplitSymbols, getStringifedSymbolKey } from './utils.js';
+import { getNormalizedPathItem, getParsedStringPath, getStringifedSymbolKey } from './utils.js';
 import { isNumericKey, isQuotedKey } from './validate.js';
 
 export type * from './internalTypes.js';
 
-const DOTTY_WITH_BRACKETS_SYNTAX = /"[^"]+"|`[^`]+`|'[^']+'|[^.[\]]+/g;
 const VALID_KEY = /^\d+$|^[a-zA-Z_$][\w$]+$/;
 const VALID_QUOTE = /^["'`]{1}$/;
 const WHITE_SPACE = /\s/;
@@ -47,26 +46,7 @@ export function create<const P extends Path | ReadonlyPath, Q extends Quote = '"
 
 export function parse<const P extends ParseablePath>(path: P): ParsePath<P> {
   if (typeof path === 'string') {
-    const splitPath = getSplitSymbols(path);
-    const completePath: Path = [];
-
-    splitPath.forEach((split) => {
-      if (typeof split === 'string') {
-        const dottyBracketItems = split ? split.match(DOTTY_WITH_BRACKETS_SYNTAX) : null;
-
-        if (dottyBracketItems) {
-          dottyBracketItems.forEach((value) => {
-            completePath.push(getNormalizedPathItem(value));
-          });
-
-          return;
-        }
-      }
-
-      completePath.push(split);
-    });
-
-    return completePath as ParsePath<P>;
+    return getParsedStringPath(path) as ParsePath<P>;
   }
 
   if (Array.isArray(path)) {

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,22 +1,26 @@
-export type PathItem = number | string;
+export type SerializablePathItem = number | string;
+export type PathItem = SerializablePathItem | symbol;
 export type Path = PathItem[];
 export type ReadonlyPath = readonly PathItem[];
+export type ParseablePath = Path | ReadonlyPath | PathItem;
 
 export type NumericKey = `${number}`;
 export type Quote = '"' | "'" | '`';
-export type QuotedKey = `${Quote}${PathItem}${Quote}`;
+export type QuotedKey = `${Quote}${SerializablePathItem}${Quote}`;
 
-type BracketedKey<Key extends PathItem> = `[${Key}]`;
-type BracketedQuotedKey<Key extends PathItem, Q extends Quote> = BracketedKey<`${Q}${Key}${Q}`>;
+export type SymbolKey = '<<symbol>>';
+
+type BracketedKey<Key extends SerializablePathItem> = `[${Key}]`;
+type BracketedQuotedKey<Key extends SerializablePathItem, Q extends Quote> = BracketedKey<`${Q}${Key}${Q}`>;
 type JoinedKey<
-  Key extends PathItem,
+  Key extends SerializablePathItem,
   Q extends Quote,
   S extends string,
   Rest extends unknown[],
   D extends string,
 > = '.' extends S ? CreateNarrowPath<Rest, Q, `${Key}`> : CreateNarrowPath<Rest, Q, `${S}${D}${Key}`>;
 type JoinNarrowPath<
-  Key extends PathItem,
+  Key extends SerializablePathItem,
   Q extends Quote,
   S extends string,
   Rest extends unknown[],
@@ -34,7 +38,9 @@ export type CreateNarrowPath<P, Q extends Quote, S extends string> = P extends [
           : Key extends `${string}.${string}`
             ? JoinNarrowPath<BracketedQuotedKey<Key, Q>, Q, S, Rest>
             : JoinNarrowPath<Key, Q, S, Rest, '.'>
-      : S
+      : Key extends symbol
+        ? JoinNarrowPath<BracketedKey<SymbolKey>, Q, S, Rest>
+        : S
   : S;
 
 export type CreatePath<P, Q extends Quote> = string[] extends P

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -53,7 +53,7 @@ export type CreatePath<P, Q extends Quote> = string[] extends P
 
 type SplitDots<P extends string> = P extends `${infer S}.${infer E}` ? [...SplitDots<S>, ...SplitDots<E>] : [P];
 
-type SplitString<P extends string, A extends string[]> = P extends `${infer S}[${infer C}].${infer R}`
+type SplitString<P extends string, A extends Array<string | symbol>> = P extends `${infer S}[${infer C}].${infer R}`
   ? '' extends S
     ? [...A, ...SplitString<C, []>, ...SplitString<R, []>]
     : [...A, ...SplitDots<S>, ...SplitString<C, []>, ...SplitString<R, []>]
@@ -71,7 +71,9 @@ type SplitString<P extends string, A extends string[]> = P extends `${infer S}[$
             ? [...A, N]
             : P extends `${Quote}${infer C}${Quote}`
               ? [...A, C]
-              : [...A, ...SplitDots<P>];
+              : SymbolKey extends P
+                ? [...A, symbol]
+                : [...A, ...SplitDots<P>];
 
 type ParseNarrowPath<P, A extends unknown[]> = P extends [infer Item, ...infer Rest]
   ? Item extends PathItem
@@ -82,7 +84,9 @@ type ParseNarrowPath<P, A extends unknown[]> = P extends [infer Item, ...infer R
     : P extends number
       ? [...A, P]
       : P extends string
-        ? SplitString<P, []>
+        ? SymbolKey extends P
+          ? symbol
+          : SplitString<P, []>
         : A;
 
 export type ParsePath<P> = string extends P

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,12 @@
 import type { Path, PathItem } from './internalTypes.js';
 import { isNumericKey, isQuotedKey } from './validate.js';
 
+const symbolToString = new Map<symbol, string>();
+const stringToSymbol = new Map<string, symbol>();
+
 const DOTTY_WITH_BRACKETS_SYNTAX = /"[^"]+"|`[^`]+`|'[^']+'|[^.[\]]+/g;
 const SYMBOL_HIDDEN_CHARACTERS = '\u200b';
-const SYMBOL_VALUE = /\[\u200bSymbol\(([^)]+)\)\u200b\]/g;
+const SYMBOL_VALUE = /\[\u200b*Symbol\(([^)\]]+)\)\]/g;
 
 export function getNormalizedPathItem(pathItem: PathItem) {
   if (typeof pathItem !== 'string') {
@@ -64,6 +67,11 @@ export function getParsedStringPath(path: string): Path {
   return parsedPath;
 }
 
+let hiddenCharacterLength = 1;
+
 export function getStringifedSymbolKey(pathItem: symbol): string {
-  return `${SYMBOL_HIDDEN_CHARACTERS}${pathItem.toString()}${SYMBOL_HIDDEN_CHARACTERS}`;
+  const string = pathItem.toString();
+  const hiddenCharacters = Array.from({ length: hiddenCharacterLength++ }, () => SYMBOL_HIDDEN_CHARACTERS).join('');
+
+  return `${hiddenCharacters}${string}`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,69 @@
 import type { PathItem } from './internalTypes.js';
 import { isNumericKey, isQuotedKey } from './validate.js';
 
+const SYMBOL_HIDDEN_CHARACTERS = '\u200b';
+const SYMBOL_VALUE = /\[\u200bSymbol\(([^)]+)\)\u200b\]/g;
+
+export function getExtractedSymbolValue(pathItem: string): symbol | undefined {
+  const symbol = SYMBOL_VALUE.exec(pathItem);
+
+  return symbol ? Symbol(symbol[1]) : undefined;
+}
+
 export function getNormalizedPathItem(pathItem: PathItem) {
-  if (typeof pathItem === 'string' && isQuotedKey(pathItem)) {
+  if (typeof pathItem !== 'string') {
+    return pathItem;
+  }
+
+  if (isQuotedKey(pathItem)) {
     pathItem = pathItem.slice(1, pathItem.length - 1);
+  } else {
+    const symbol = SYMBOL_VALUE.exec(pathItem);
+
+    if (symbol) {
+      return Symbol(symbol[1]);
+    }
   }
 
   return isNumericKey(pathItem) ? +pathItem : pathItem;
+}
+
+export function getSplitSymbols(path: string): Array<string | symbol> {
+  const matches = Array.from(path.matchAll(SYMBOL_VALUE));
+
+  if (!matches.length) {
+    return [path];
+  }
+
+  const splitPath: Array<string | symbol> = [];
+
+  let nextStartIndex = 0;
+
+  matches.forEach((match, index) => {
+    const before = path.slice(nextStartIndex, match.index);
+
+    if (before) {
+      splitPath.push(before);
+    }
+
+    nextStartIndex = match.index + match[0].length;
+
+    splitPath.push(Symbol(match[1]));
+
+    let after = path.slice(nextStartIndex);
+
+    if (after && index === matches.length - 1) {
+      if (after.startsWith('.')) {
+        after = after.slice(1);
+      }
+
+      splitPath.push(after);
+    }
+  });
+
+  return splitPath;
+}
+
+export function getStringifedSymbolKey(pathItem: symbol): string {
+  return `${SYMBOL_HIDDEN_CHARACTERS}${pathItem.toString()}${SYMBOL_HIDDEN_CHARACTERS}`;
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,9 +1,9 @@
-import type { NumericKey, PathItem, QuotedKey } from './internalTypes.js';
+import type { NumericKey, QuotedKey, SerializablePathItem } from './internalTypes.js';
 
 const NUMBER = /^\d+$/i;
 const QUOTED_KEY = /^"[^"]+"|`[^`]+`|'[^']+'$/;
 
-export function isNumericKey(pathItem: PathItem): pathItem is NumericKey {
+export function isNumericKey(pathItem: SerializablePathItem): pathItem is NumericKey {
   return typeof pathItem === 'number' || NUMBER.test(pathItem);
 }
 


### PR DESCRIPTION
## Reason for change

Symbols are a valid property type for objects, however they do not stringify in a way that represents their uniqueness, so this library has not supported them prior. However, I thought of a way to support them across use of both `create` and `parse`, both for types and runtime.

## Change

### Runtime

When a path is created with symbols, a string is created from its own `toString()` method, however it is prefixed with a unique number of zero-width string values to make it _read_ normally but be perceived as unique. Then, when the string is parsed, it looks up in a cache to get the original symbol value.

This has similar issues as symbol polyfills, as it is a cache that grows and never shrinks over time. However, the expectation is that the number of unique symbols used are small in general, let alone as object keys, so it is an acceptable cost.

### Types

Unline string or number path items, symbols cannot be statically analyzed for their value. As such, they have a string representation of `Symbol()` (no value) in the path, and the simple type `symbol` when in a parsed array.